### PR TITLE
macOS: drop explicit -arch flags

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -21,8 +21,8 @@ MEMTEST_OUTPUT ?= $(CURDIR)/../_build/memory_test
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CXX ?= c++
-	CXXFLAGS += -O3 -arch x86_64 -finline-functions
-	LDFLAGS += -arch x86_64 -flat_namespace -undefined suppress
+	CXXFLAGS += -O3 -finline-functions
+	LDFLAGS += -flat_namespace -undefined suppress
 	PSOURCES = prometheus_process_info_macos.cc
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CXX ?= c++


### PR DESCRIPTION
Fixes #23.

Without `-arch x86_64`, the Apple toolchain automatically picks the target based upon the current runtime architecture.

Meaning:
- on Apple Silicon, running natively (= aarch64), the resulting binary will be for aarch64 (good!)
- on Apple Silicon, running under Rosetta, emulating x86_64, the resulting binary will be for x86_64 (good!)

Tests done:
- Builds on aarch64 macOS 11.1, Xcode 12.2 `Apple clang version 12.0.0 (clang-1200.0.32.28)`. Both native and under Rosetta.
- Builds on x86_64 macOS 11.1, Xcode 12.2 `Apple clang version 12.0.0 (clang-1200.0.32.27)`.
- My app works with a native (aarch64) Erlang 23.2.1 from Homebrew now.
