### PR TITLE
fix: update `erl` invocation for OTP 26

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,9 +6,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -noshell -s init stop)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)])." -noshell -s init stop)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)])." -noshell -s init stop)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so


### PR DESCRIPTION
On OTP 26 a [race-condition was fixed](https://github.com/erlang/otp/issues/6916) and that made this type of invocations always fail. By moving the `-s init stop` part towards the end of the command, the command now works.